### PR TITLE
Get metadata for images

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 iscc-sdk==0.8.0
+pywikibot==10.0.0

--- a/src/metadata_collector.py
+++ b/src/metadata_collector.py
@@ -1,0 +1,130 @@
+import pywikibot
+from pywikibot import FilePage
+from pywikibot.data.api import Request
+from pywikibot.site import APISite
+
+
+class MetadataCollector:
+    def __init__(self, commons_filename: str) -> None:
+        self._site: APISite = pywikibot.Site()
+        self._page: FilePage = pywikibot.FilePage(self._site, commons_filename)
+        self._filename = commons_filename
+
+    def get_url(self) -> str:
+        try:
+            url = self._page.latest_file_info.descriptionshorturl
+        except Exception:
+            raise MissingMetadataError("Couldn't retrieve URL.")
+
+        return url
+
+    def get_name(self) -> str:
+        return (self._get_name_from_label()
+                or self._get_name_from_title()
+                or self._get_name_from_filename())
+
+    def _get_name_from_label(self) -> str:
+        entity = self._get_digital_representation()
+        if entity is None:
+            return None
+
+        labels = entity.get("labels", {})
+        label = labels.get("en", {}).get("value")
+        return label
+
+    def _get_digital_representation(self) -> dict:
+        sdc = self._get_sdc()
+        if sdc is None:
+            return None
+
+        # P6243 = "digital representation of"
+        digital_representation = self._get_property(sdc, "P6243")
+        if digital_representation is None:
+            return None
+
+        item = self._get_entity(digital_representation.get("id"))
+        return item
+
+    def _get_name_from_title(self) -> str:
+        entity = self._get_digital_representation()
+        if entity is None:
+            return None
+
+        # P1476 = "title"
+        title = self._get_property(entity, "P1476")
+        if title is None:
+            return None
+
+        return title.get("text")
+
+    def _get_name_from_filename(self) -> str:
+        # Remove the file extension.
+        name_from_file = self._filename.rsplit(".", 1)[0]
+        return name_from_file
+
+    def _get_sdc(self) -> dict:
+        sdc = self._get_entity(f"M{self._page.pageid}")
+        return sdc
+
+    def _get_entity(self, id_: str) -> dict:
+        parameters = {
+            "action": "wbgetentities",
+            "ids": id_
+        }
+        request = Request(site=self._site, parameters=parameters)
+        response = request.submit()
+        item_id = list(response.get("entities", {}).keys())[0]
+        entity = response.get("entities", {}).get(item_id)
+        return entity
+
+    def get_license(self) -> str:
+        return (self._get_license_for_depicted()
+                or self._get_license_for_image())
+
+    def _get_license_for_image(self) -> str:
+        sdc = self._get_sdc()
+        if sdc is None:
+            return None
+
+        # P275 = "copyright license"
+        license_property = self._get_property(sdc, "P275")
+        if license_property is None:
+            return None
+
+        license_item_id = license_property.get("id")
+        license_item = self._get_entity(license_item_id)
+        # P856 = "official website"
+        license_url = self._get_property(license_item, "P856")
+
+        return license_url
+
+    def _get_license_for_depicted(self) -> str:
+        depicted = self._get_digital_representation()
+        if depicted is None:
+            return None
+
+        license_property = self._get_property(depicted, "P275")
+        if license_property is None:
+            return None
+
+        license_item_id = license_property.get("id")
+        license_item = self._get_entity(license_item_id)
+        # P856 = "official website"
+        license_url = self._get_property(license_item, "P856")
+        return license_url
+
+    def _get_property(self, entity: dict, property_name: str):
+        property_ = (
+            entity.get("claims", {})
+            or entity.get("statements", {})
+        ).get(property_name, [None])[0]
+
+        if property_ is None:
+            return None
+
+        value = property_.get("mainsnak", {}).get("datavalue", {}).get("value")
+        return value
+
+
+class MissingMetadataError(Exception):
+    pass

--- a/tests/test_metadata_collector.py
+++ b/tests/test_metadata_collector.py
@@ -1,0 +1,140 @@
+from unittest import TestCase
+from unittest.mock import PropertyMock, patch
+
+import pytest
+from pywikibot.exceptions import NoPageError
+
+from metadata_collector import MetadataCollector, MissingMetadataError
+
+
+class MetadataCollectorTestCase(TestCase):
+    def setUp(self):
+        file_page_patcher = patch("pywikibot.FilePage")
+        self.FilePage = file_page_patcher.start()
+        site_patcher = patch("pywikibot.Site")
+        self.Site = site_patcher.start()
+        request_patcher = patch("metadata_collector.Request")
+        self.Request = request_patcher.start()
+        self._responses = {}
+        self.Request.return_value.submit.side_effect = self._response
+
+    def tearDown(self):
+        patch.stopall()
+
+    def _response(self, *args, **kwargs):
+        parameters = self.Request.call_args.kwargs.get("parameters")
+        if parameters.get("action") == "wbgetentities":
+            ids = parameters.get("ids", "")
+            return self._responses.get(ids)
+
+    def _mock_response(
+        self,
+        entity_id,
+        statements=None,
+        claims=None,
+        labels=None
+    ):
+        entity = {}
+        if statements:
+            response_statements = {}
+            for k, v in statements.items():
+                response_statements[k] = [{
+                    "mainsnak": {
+                        "datavalue": {
+                            "value": v
+                        }
+                    }
+                }]
+            entity["statements"] = response_statements
+
+        if claims:
+            response_claims = {}
+            for k, v in claims.items():
+                response_claims[k] = [{
+                    "mainsnak": {
+                        "datavalue": {
+                            "value": v
+                        }
+                    }
+                }]
+            entity["claims"] = response_claims
+
+        if labels:
+            response_labels = {}
+            for k, v in labels.items():
+                response_labels[k] = {"value": v}
+            entity["labels"] = response_labels
+
+        response = {
+            "entities": {
+                entity_id: entity
+            }
+        }
+        self._responses[entity_id] = response
+
+    def test_get_url(self):
+        self.FilePage.return_value.latest_file_info.descriptionshorturl = "https://commons.wikimedia.org/wiki/Special:Redirect/page/123"  # noqa: E501
+
+        metadata_collector = MetadataCollector("Image on Commons.jpeg")
+
+        url = metadata_collector.get_url()
+
+        assert url == "https://commons.wikimedia.org/wiki/Special:Redirect/page/123"  # noqa: E501
+
+    def test_get_url_missing_file(self):
+        metadata_collector = MetadataCollector("Image NOT on Commons.jpeg")
+        page_class = type(metadata_collector._page)
+        error = NoPageError(page=metadata_collector._page)
+        page_class.latest_file_info = PropertyMock(side_effect=error)
+
+        with pytest.raises(MissingMetadataError):
+            metadata_collector.get_url()
+
+    def test_get_name_from_filename(self):
+        self.FilePage.return_value.pageid = "123"
+        self._mock_response("M123", statements={"P6243": {"id": "Q456"}})
+        self._mock_response("Q456", labels={})
+        metadata_collector = MetadataCollector("Image on Commons.jpeg")
+
+        name = metadata_collector.get_name()
+
+        assert name == "Image on Commons"
+
+    def test_get_name_from_caption(self):
+        self.FilePage.return_value.pageid = "123"
+        self._mock_response("M123", statements={"P6243": {"id": "Q456"}})
+        self._mock_response("Q456", labels={"en": "Label"})
+        metadata_collector = MetadataCollector("Image on Commons.jpeg")
+        name = metadata_collector.get_name()
+
+        assert name == "Label"
+
+    def test_get_name_from_title(self):
+        self.FilePage.return_value.pageid = "123"
+        metadata_collector = MetadataCollector("Image on Commons.jpeg")
+        self._mock_response("M123", statements={"P6243": {"id": "Q456"}})
+        self._mock_response("Q456", claims={"P1476": {"text": "Title"}})
+        name = metadata_collector.get_name()
+
+        assert name == "Title"
+
+    def test_get_license_for_image(self):
+        self.FilePage.return_value.pageid = "123"
+        metadata_collector = MetadataCollector("Image on Commons.jpeg")
+        self._mock_response("M123", statements={"P275": {"id": "Q456"}})
+        self._mock_response("Q456", claims={"P856": "www.license.org"})
+
+        license = metadata_collector.get_license()
+
+        assert license == "www.license.org"
+
+    def test_get_license_for_depicted(self):
+        self.FilePage.return_value.pageid = "123"
+        metadata_collector = MetadataCollector("Image on Commons.jpeg")
+        self._mock_response("M123", statements={"P6243": {"id": "Q456"}})
+        self._mock_response("Q456", statements={"P275": {"id": "Q789"}})
+        self._mock_response("Q789", claims={"P856": "www.license.org"})
+
+        license = metadata_collector.get_license()
+
+        assert license == "www.license.org"

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,9 @@ commands = pytest tests/
 
 [pytest]
 pythonpath = src/
+filterwarnings =
+    # These warnings come from Pymupdf.
+    ignore:builtin type (SwigPyPacked|SwigPyObject|swigvarlink) has no __module__ attribute:DeprecationWarning
 
 [testenv:flake8]
 commands = flake8


### PR DESCRIPTION
Adds `MetadataCollector` that can get name, URL and license.

If an image is a digital representation the name is taken first from the works title and then label. If neither of them exist or if the image isn't a digital representation the filename is used.

URL points to the image page using Special:Redirect.

The license is the URL of the license from P856 ("official website"). It's first taken from a digital representation if there is any. Otherwise it's taken from the image itself.

Task: T390950