### PR TITLE
Add declaration journal

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ requests==2.32.3
 PyJWT[crypto]==2.10.1
 py-multihash==2.0.1
 base58==2.1.1
+SQLAlchemy==2.0.41

--- a/src/make_declaration.py
+++ b/src/make_declaration.py
@@ -1,10 +1,12 @@
 import logging
-from argparse import ArgumentParser
+from argparse import ArgumentParser, Namespace
+from datetime import datetime
 from time import time
 
 from pywikibot import FilePage, Site
 
 from declaration_api_connector import DeclarationApiConnector
+from declaration_journal import DeclarationJournal, create_journal
 from file_fetcher import FileFetcher
 from iscc_generator import IsccGenerator
 from metadata_collector import MetadataCollector
@@ -12,22 +14,51 @@ from metadata_collector import MetadataCollector
 logger = logging.getLogger(__name__)
 
 
-def process_file(commons_filename, args):
+def process_file(
+    commons_filename: str,
+    args: Namespace,
+    journal: DeclarationJournal
+):
     logger.info(f"Processing '{commons_filename}'.")
 
     site = Site("commons")
     page = FilePage(site, commons_filename)
-    file_fetcher = FileFetcher()
-
     metadata_collector = MetadataCollector(site, page)
-    path = file_fetcher.fetch_file(page)
-    print(f"File size: {page.latest_file_info.size / 1024 / 1024:.0f} MB")
-    iscc_generator = IsccGenerator(path)
     api_connector = DeclarationApiConnector(
         args.dry,
         args.member_credentials_file,
         args.private_key_file
     )
+
+    matching_page_id = journal.get_image_hash_match(page.latest_file_info.sha1)
+    if matching_page_id is not None:
+        logger.info(
+            f"Image hash is the same as for page id {matching_page_id}. "
+            "Not generating ISCC."
+        )
+    else:
+        # TODO: Maybe add declaration even when it's a duplicate so it
+        # doesn't need to be looked up on Commons?
+        declaration_id = journal.add_declaration(
+            page_id=page.pageid,
+            revision_id=page.latest_revision_id
+        )
+        file_fetcher = FileFetcher()
+        path = file_fetcher.fetch_file(page)
+        print(f"File size: {page.latest_file_info.size / 1024 / 1024:.0f} MB")
+
+        iscc_generator = IsccGenerator(path)
+        logger.info("Generating ISCC.")
+        iscc = iscc_generator.generate()
+
+        journal.update_declaration(
+            declaration_id,
+            image_hash=page.latest_file_info.sha1,
+            iscc=iscc
+        )
+
+    if args.iscc:
+        return
 
     logger.info("Getting location.")
     location = metadata_collector.get_url()
@@ -35,37 +66,42 @@ def process_file(commons_filename, args):
     name = metadata_collector.get_name()
     logger.info("Getting license.")
     license_url = metadata_collector.get_license()
-    logger.info("Generating ISCC.")
-    iscc = iscc_generator.generate()
     logger.info("Making declaration.")
     api_connector.request_declaration(name, iscc, location, license_url)
     logger.info(f"Done with '{commons_filename}'.")
 
 
 if __name__ == "__main__":
-    logging.basicConfig(
-        level=logging.DEBUG,
-        format="{asctime};{name};{levelname};{message}",
-        style="{"
-    )
     parser = ArgumentParser()
     parser.add_argument("--dry", "-d", action="store_true")
+    parser.add_argument("--verbose", "-v", action="store_true")
+    parser.add_argument("--iscc", "-i", action="store_true")
     parser.add_argument("member_credentials_file")
     parser.add_argument("private_key_file")
     parser.add_argument("list_file")
     args = parser.parse_args()
+
+    log_level = logging.DEBUG if args.verbose else logging.INFO
+    logging.basicConfig(
+        level=log_level,
+        format="{asctime};{name};{levelname};{message}",
+        style="{"
+    )
 
     with open(args.list_file) as f:
         files = [g.strip() for g in f]
 
     start_total_time = time()
     error_files = []
+    timestamp = datetime.now().replace(microsecond=0)
+    print(f"START: {timestamp}")
     print(f"Processing {len(files)} files.")
     for i, f in enumerate(files):
+        declaration_journal = create_journal("sqlite:///tmp.db")
         print(f"{i + 1}/{len(files)}: {f}")
         start_time = time()
         try:
-            process_file(f, args)
+            process_file(f, args, declaration_journal)
         except Exception:
             logger.exception(f"Error while processing file: '{f}'.")
             print("ERROR")
@@ -76,3 +112,5 @@ if __name__ == "__main__":
     if error_files:
         print("Some requests failed. See log for details:")
         print("\n".join(error_files))
+    timestamp = datetime.now().replace(microsecond=0)
+    print(f"DONE: {timestamp}")

--- a/tests/test_declaration_journal.py
+++ b/tests/test_declaration_journal.py
@@ -1,0 +1,70 @@
+from unittest import TestCase
+
+from declaration_journal import create_journal
+
+
+class DeclarationJournalTestCase(TestCase):
+    def setUp(self):
+        self._declaration_journal = create_journal("sqlite:///:memory:")
+
+    def test_add_declaration(self):
+        self._declaration_journal.add_declaration(
+            page_id=123,
+            revision_id=456
+        )
+        self._declaration_journal.add_declaration(
+            page_id=234,
+            revision_id=567
+        )
+
+        declarations = self._declaration_journal.get_declarations()
+
+        assert declarations[0].page_id == 123
+        assert declarations[0].revision_id == 456
+        assert declarations[1].page_id == 234
+        assert declarations[1].revision_id == 567
+
+    def test_update_declaration(self):
+        declaration_id = self._declaration_journal.add_declaration(
+            page_id=123,
+            revision_id=456
+        )
+        self._declaration_journal.add_declaration(
+            page_id=234,
+            revision_id=567
+        )
+        self._declaration_journal.update_declaration(
+            declaration_id,
+            revision_id=678
+        )
+
+        declarations = self._declaration_journal.get_declarations()
+
+        assert declarations[0].page_id == 123
+        assert declarations[0].revision_id == 678
+        assert declarations[1].page_id == 234
+        assert declarations[1].revision_id == 567
+
+    def test_get_image_hash_match(self):
+        declaration_id = self._declaration_journal.add_declaration(
+            page_id=123,
+            revision_id=456
+        )
+        self._declaration_journal.update_declaration(
+            declaration_id,
+            image_hash="hash123456789"
+        )
+
+        match = self._declaration_journal.get_image_hash_match("hash123456789")
+
+        assert match == 123
+
+    def test_get_image_hash_match_no_match(self):
+        self._declaration_journal.add_declaration(
+            page_id=123,
+            revision_id=456
+        )
+
+        match = self._declaration_journal.get_image_hash_match("hashOTHER")
+
+        assert match is None


### PR DESCRIPTION
The journal is used to track what images have been processed. Skips ISCC generation for images for which that has already been done. The journal is stored as a database. Fields for journal entries include:

* timestamp - when the entry was added
* page_id
* revision_id
* image_hash - from Commons
* iscc

Adds the flag `--iscc`/`-i` to only generate ISCC for an image. This can be used to do this beforehand and used in later requests. Using ISCC from journal isn't yet implemented and will be added in a future update.

Task: T395105