### PR TITLE
Update declaration if it matches page id

### DIFF
--- a/src/declaration_journal.py
+++ b/src/declaration_journal.py
@@ -39,27 +39,27 @@ class DeclarationJournal:
     def add_declaration(
         self,
         page_id: int,
-        revision_id: int
-    ) -> int:
+        revision_id: int,
+        image_hash: str
+    ) -> Declaration:
         declaration = Declaration(
             page_id=page_id,
             created_timestamp=datetime.now(),
             updated_timestamp=datetime.now(),
-            revision_id=revision_id
+            revision_id=revision_id,
+            image_hash=image_hash
         )
         self._session.add(declaration)
         self._session.commit()
-        return declaration.id
+        return declaration
 
     def update_declaration(
         self,
-        declaration_id: int,
+        declaration: Declaration,
         revision_id: int | None = None,
         image_hash: str | None = None,
         iscc: str | None = None
     ):
-        statement = select(Declaration).where(Declaration.id == declaration_id)
-        declaration = self._session.scalars(statement).one_or_none()
         if declaration is None:
             return
 
@@ -84,13 +84,21 @@ class DeclarationJournal:
 
         return result
 
-    def get_image_hash_match(self, hash: str) -> int:
+    def get_page_id_match(self, page_id: int) -> Declaration:
+        statement = select(Declaration).where(Declaration.page_id == page_id)
+        declaration = self._session.scalars(statement).one_or_none()
+        if declaration is None:
+            return None
+
+        return declaration
+
+    def get_image_hash_match(self, hash: str) -> Declaration:
         statement = select(Declaration).where(Declaration.image_hash == hash)
         declaration = self._session.scalars(statement).one_or_none()
         if declaration is None:
             return None
 
-        return declaration.page_id
+        return declaration
 
 
 def create_journal(database_url: str):

--- a/tests/test_declaration_journal.py
+++ b/tests/test_declaration_journal.py
@@ -10,34 +10,40 @@ class DeclarationJournalTestCase(TestCase):
     def test_add_declaration(self):
         self._declaration_journal.add_declaration(
             page_id=123,
-            revision_id=456
+            revision_id=456,
+            image_hash="hash123456789"
         )
         self._declaration_journal.add_declaration(
             page_id=234,
-            revision_id=567
+            revision_id=567,
+            image_hash="hash234567890"
         )
 
         declarations = self._declaration_journal.get_declarations()
 
         assert declarations[0].page_id == 123
         assert declarations[0].revision_id == 456
+        assert declarations[0].image_hash == "hash123456789"
         assert declarations[1].page_id == 234
         assert declarations[1].revision_id == 567
+        assert declarations[1].image_hash == "hash234567890"
 
     def test_update_declaration(self):
-        declaration_id = self._declaration_journal.add_declaration(
+        declaration = self._declaration_journal.add_declaration(
             page_id=123,
-            revision_id=456
+            revision_id=456,
+            image_hash="hash123456789"
         )
         self._declaration_journal.add_declaration(
             page_id=234,
-            revision_id=567
-        )
-        self._declaration_journal.update_declaration(
-            declaration_id,
-            revision_id=678
+            revision_id=567,
+            image_hash="hash234567890"
         )
 
+        self._declaration_journal.update_declaration(
+            declaration,
+            revision_id=678
+        )
         declarations = self._declaration_journal.get_declarations()
 
         assert declarations[0].page_id == 123
@@ -46,25 +52,45 @@ class DeclarationJournalTestCase(TestCase):
         assert declarations[1].revision_id == 567
 
     def test_get_image_hash_match(self):
-        declaration_id = self._declaration_journal.add_declaration(
+        declaration = self._declaration_journal.add_declaration(
             page_id=123,
-            revision_id=456
-        )
-        self._declaration_journal.update_declaration(
-            declaration_id,
+            revision_id=456,
             image_hash="hash123456789"
         )
 
         match = self._declaration_journal.get_image_hash_match("hash123456789")
 
-        assert match == 123
+        assert match == declaration
 
     def test_get_image_hash_match_no_match(self):
         self._declaration_journal.add_declaration(
             page_id=123,
-            revision_id=456
+            revision_id=456,
+            image_hash="hash123456789"
         )
 
         match = self._declaration_journal.get_image_hash_match("hashOTHER")
+
+        assert match is None
+
+    def test_get_page_id_match(self):
+        declaration = self._declaration_journal.add_declaration(
+            page_id=123,
+            revision_id=456,
+            image_hash="hash123456789"
+        )
+
+        match = self._declaration_journal.get_page_id_match(123)
+
+        assert match == declaration
+
+    def test_get_page_id_match_no_match(self):
+        self._declaration_journal.add_declaration(
+            page_id=123,
+            revision_id=456,
+            image_hash="hash123456789"
+        )
+
+        match = self._declaration_journal.get_page_id_match(234)
 
         assert match is None


### PR DESCRIPTION
Instead of adding a new declaration update the one already in the journal. This is relevant for declarations that not yet have ISCC.