### PR TITLE
Add tags to journal

### DIFF
--- a/alembic-files/versions/626dc7b4c638_add_tag_and_association_tables.py
+++ b/alembic-files/versions/626dc7b4c638_add_tag_and_association_tables.py
@@ -1,0 +1,41 @@
+"""Add tag and association tables
+
+Revision ID: 626dc7b4c638
+Revises: 6ddb18dff0bf
+Create Date: 2025-07-03 15:17:26.235598
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '626dc7b4c638'
+down_revision: Union[str, None] = '6ddb18dff0bf'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table('tag',
+    sa.Column('id', sa.Integer(), nullable=False),
+    sa.Column('label', sa.String(length=50), nullable=False),
+    sa.PrimaryKeyConstraint('id')
+    )
+    op.create_table('tag_association',
+    sa.Column('declartion_id', sa.Integer(), nullable=False),
+    sa.Column('tag_id', sa.Integer(), nullable=False),
+    sa.ForeignKeyConstraint(['declartion_id'], ['declaration.id'], ),
+    sa.ForeignKeyConstraint(['tag_id'], ['tag.id'], ),
+    sa.PrimaryKeyConstraint('declartion_id', 'tag_id')
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_table('tag_association')
+    op.drop_table('tag')
+

--- a/tests/test_declaration_journal.py
+++ b/tests/test_declaration_journal.py
@@ -1,19 +1,35 @@
+from datetime import datetime
 from unittest import TestCase
 
-from declaration_journal import create_journal
+from declaration_journal import Declaration, Tag, create_journal
 
 
 class DeclarationJournalTestCase(TestCase):
     def setUp(self):
         self._declaration_journal = create_journal("sqlite:///:memory:")
 
+    def _add_declaration(self, **kwargs):
+        now = datetime.now()
+        fields = {
+            "page_id": 123,
+            "revision_id": 456,
+            "created_timestamp": now,
+            "updated_timestamp": now
+        }
+        fields.update(kwargs)
+        declaration = Declaration(**fields)
+        self._declaration_journal._session.add(declaration)
+        return declaration
+
     def test_add_declaration(self):
         self._declaration_journal.add_declaration(
+            {"tag-1", "tag-2"},
             page_id=123,
             revision_id=456,
             image_hash="hash123456789"
         )
         self._declaration_journal.add_declaration(
+            {"tag-3"},
             page_id=234,
             revision_id=567,
             image_hash="hash234567890"
@@ -21,24 +37,18 @@ class DeclarationJournalTestCase(TestCase):
 
         declarations = self._declaration_journal.get_declarations()
 
+        assert declarations[0].tags == {Tag(label="tag-1"), Tag(label="tag-2")}
         assert declarations[0].page_id == 123
         assert declarations[0].revision_id == 456
         assert declarations[0].image_hash == "hash123456789"
+        assert declarations[1].tags == {Tag(label="tag-3")}
         assert declarations[1].page_id == 234
         assert declarations[1].revision_id == 567
         assert declarations[1].image_hash == "hash234567890"
 
     def test_update_declaration(self):
-        declaration = self._declaration_journal.add_declaration(
-            page_id=123,
-            revision_id=456,
-            image_hash="hash123456789"
-        )
-        self._declaration_journal.add_declaration(
-            page_id=234,
-            revision_id=567,
-            image_hash="hash234567890"
-        )
+        declaration = self._add_declaration(page_id=123, revision_id=456)
+        self._add_declaration(page_id=234, revision_id=567)
 
         self._declaration_journal.update_declaration(
             declaration,
@@ -52,44 +62,28 @@ class DeclarationJournalTestCase(TestCase):
         assert declarations[1].revision_id == 567
 
     def test_get_image_hash_match(self):
-        declaration = self._declaration_journal.add_declaration(
-            page_id=123,
-            revision_id=456,
-            image_hash="hash123456789"
-        )
+        declaration = self._add_declaration(image_hash="hash123456789")
 
         match = self._declaration_journal.get_image_hash_match("hash123456789")
 
         assert match == declaration
 
     def test_get_image_hash_match_no_match(self):
-        self._declaration_journal.add_declaration(
-            page_id=123,
-            revision_id=456,
-            image_hash="hash123456789"
-        )
+        self._add_declaration(image_hash="hash123456789")
 
         match = self._declaration_journal.get_image_hash_match("hashOTHER")
 
         assert match is None
 
     def test_get_page_id_match(self):
-        declaration = self._declaration_journal.add_declaration(
-            page_id=123,
-            revision_id=456,
-            image_hash="hash123456789"
-        )
+        declaration = self._add_declaration(page_id=123)
 
         match = self._declaration_journal.get_page_id_match(123)
 
         assert match == declaration
 
     def test_get_page_id_match_no_match(self):
-        self._declaration_journal.add_declaration(
-            page_id=123,
-            revision_id=456,
-            image_hash="hash123456789"
-        )
+        self._add_declaration(page_id=123)
 
         match = self._declaration_journal.get_page_id_match(234)
 


### PR DESCRIPTION
A set of tags can be added to each declaration. The tags are stored in a separate table and that is expanded when needed.

A batch tag with the label "batch:<FILENAME WITHOUT EXTENSITON>" is added to all declarations.

Also adds an argument to quit on the first error when processing files.

Task: T396868