### PR TITLE
Use thumbnails for ISCC generation

### DIFF
--- a/alembic-files/versions/20262d93dd61_add_width_and_height_for_files.py
+++ b/alembic-files/versions/20262d93dd61_add_width_and_height_for_files.py
@@ -1,0 +1,30 @@
+"""Add width and height for files
+
+Revision ID: 20262d93dd61
+Revises: 626dc7b4c638
+Create Date: 2025-07-04 10:54:06.289904
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '20262d93dd61'
+down_revision: Union[str, None] = '626dc7b4c638'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column('declaration', sa.Column('width', sa.Integer(), nullable=True))
+    op.add_column('declaration', sa.Column('height', sa.Integer(), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column('declaration', 'height')
+    op.drop_column('declaration', 'width')

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ base58==2.1.1
 SQLAlchemy==2.0.41
 PyMySQL==1.1.1
 alembic==1.16.1
+pillow==11.3.0

--- a/src/declaration_journal.py
+++ b/src/declaration_journal.py
@@ -39,6 +39,8 @@ class Declaration(Base):
     revision_id: Mapped[int]
     image_hash: Mapped[Optional[str]] = mapped_column(String(41))
     file_size: Mapped[Optional[int]]
+    width: Mapped[Optional[int]]
+    height: Mapped[Optional[int]]
     download_time: Mapped[Optional[float]]
     iscc: Mapped[Optional[str]] = mapped_column(String(61))
     iscc_time: Mapped[Optional[float]]

--- a/src/file_fetcher.py
+++ b/src/file_fetcher.py
@@ -1,6 +1,8 @@
 import logging
+import os
 from tempfile import TemporaryDirectory
 
+from PIL import Image
 from pywikibot import FilePage
 
 logger = logging.getLogger(__name__)
@@ -12,9 +14,13 @@ class FileFetcher:
         # for as long as it's needed.
         self._storage = TemporaryDirectory()
 
-    def fetch_file(self, page: FilePage) -> str:
+    def fetch_file(self, page: FilePage) -> tuple[str, int, int, int]:
         filename = page.title(with_ns=False)
         path = f"{self._storage.name}/{filename}"
         logger.info(f"Downloading file: '{filename}'")
-        page.download(path)
-        return path
+        success = page.download(path, url_width=330)
+        if not success:
+            raise Exception("Failed to download file.")
+
+        image = Image.open(path)
+        return path, os.path.getsize(path), image.width, image.height

--- a/src/make_declaration.py
+++ b/src/make_declaration.py
@@ -76,18 +76,20 @@ def process_file(
             # Download file and generate ISCC.
             download_start_time = time()
             file_fetcher = FileFetcher()
-            path = file_fetcher.fetch_file(page)
-            size_mb = page.latest_file_info.size / 1024 / 1024
-            print(f"File size: {size_mb:.0f} MB")
+            path, file_size, width, height = file_fetcher.fetch_file(page)
             download_time = time() - download_start_time
+
             iscc_start_time = time()
             iscc_generator = IsccGenerator(path)
             logger.info("Generating ISCC.")
             iscc = iscc_generator.generate()
             iscc_time = time() - iscc_start_time
+
             journal.update_declaration(
                 declaration,
-                file_size=page.latest_file_info.size,
+                file_size=file_size,
+                width=width,
+                height=height,
                 download_time=download_time,
                 iscc=iscc,
                 iscc_time=iscc_time
@@ -121,7 +123,7 @@ if __name__ == "__main__":
     parser.add_argument("--verbose", "-v", action="store_true")
     parser.add_argument("--iscc", "-i", action="store_true")
     parser.add_argument("--quit-on-error", "-q", action="store_true")
-    parser.add_argument("--tag", "-t", action="append")
+    parser.add_argument("--tag", "-t", action="append", default=[])
     parser.add_argument("list_file")
     args = parser.parse_args()
 


### PR DESCRIPTION
The images are downloaded as 330 px wide versions. Height and width are added to journal entries.

Fixes:
* Error when no tags where given with `--tag`.

Task: T396998